### PR TITLE
otter: initial bringup

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcm6490-shift-otter.dts
+++ b/arch/arm64/boot/dts/qcom/qcm6490-shift-otter.dts
@@ -183,6 +183,20 @@
 			};
 		};
 
+		mem-thermal {
+			polling-delay-passive = <0>;
+
+			thermal-sensors = <&pm7250b_adc_tm 2>;
+
+			trips {
+				active-config0 {
+					temperature = <125000>;
+					hysteresis = <1000>;
+					type = "passive";
+				};
+			};
+		};
+
 		quiet-thermal {
 			polling-delay-passive = <0>;
 
@@ -654,6 +668,9 @@
 };
 
 &pm7250b_adc {
+	pinctrl-0 = <&pm7250b_adc_default>;
+	pinctrl-names = "default";
+
 	channel@4d {
 		reg = <ADC5_AMUX_THM1_100K_PU>;
 		qcom,ratiometric;
@@ -668,6 +685,14 @@
 		qcom,hw-settle-time = <200>;
 		qcom,pre-scaling = <1 1>;
 		label = "conn_therm";
+	};
+
+	channel@53 {
+		reg = <ADC5_GPIO2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time = <200>;
+		qcom,pre-scaling = <1 1>;
+		label = "mem_therm";
 	};
 };
 
@@ -686,6 +711,21 @@
 		io-channels = <&pm7250b_adc ADC5_AMUX_THM3_100K_PU>;
 		qcom,ratiometric;
 		qcom,hw-settle-time-us = <200>;
+	};
+
+	mem-therm@2 {
+		reg = <2>;
+		io-channels = <&pm7250b_adc ADC5_GPIO2_100K_PU>;
+		qcom,ratiometric;
+		qcom,hw-settle-time-us = <200>;
+	};
+};
+
+&pm7250b_gpios {
+	pm7250b_adc_default: adc-default-state {
+		pins = "gpio12";
+		function = PMIC_GPIO_FUNC_NORMAL;
+		bias-high-impedance;
 	};
 };
 


### PR DESCRIPTION
Second attempt.

- https://github.com/sc7280-mainline/linux/commit/97daf3e8cc2a11dd6a1788c007f2056df3dc1a87
  - switches panel to DSC, got artifacts - is DSC still broken or did i mess up?
- https://github.com/sc7280-mainline/linux/commit/ad5546123a4b62ad1814b1c391da48f7e38dd56c
  - "borrowed" from you, how shall i best apply authorship?
- The following patches were done already but also apply to otter, how should i proceed there with commit messages and authorship?
  - https://github.com/sc7280-mainline/linux/commit/7ecd12648d42bd9db1385964f352c4c161e0c535
  - https://github.com/sc7280-mainline/linux/commit/f22bde789e08bd1e2f35daaf3053ed4548f1b80c
  - https://github.com/sc7280-mainline/linux/commit/75b56926a055649211d172f2592d2bf996401e98