### PR TITLE
taoyao patches

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom.yaml
@@ -1060,6 +1060,7 @@ properties:
       - items:
           - enum:
               - nothing,spacewar
+              - xiaomi,taoyao
           - const: qcom,sm7325
 
       - items:

--- a/arch/arm64/boot/dts/qcom/sm7325-xiaomi-taoyao.dts
+++ b/arch/arm64/boot/dts/qcom/sm7325-xiaomi-taoyao.dts
@@ -72,6 +72,7 @@
 
 	pmic-glink {
 		compatible = "qcom,sm7325-pmic-glink",
+			     "qcom,qcm6490-pmic-glink",
 			     "qcom,pmic-glink";
 
 		#address-cells = <1>;


### PR DESCRIPTION
as you asked 2 patches:
- fixup for fixing pmic-glink DTB warning
- adding board to `qcom.yaml`

```
$ make ARCH=arm64 CHECK_DTBS=1 qcom/sm7325-xiaomi-taoyao.dtb
arch/arm64/Makefile:33: Detected assembler with broken .inst; disassembly will be unreliable
  SYNC    include/config/auto.conf
arch/arm64/Makefile:33: Detected assembler with broken .inst; disassembly will be unreliable
  UPD     include/config/kernel.release
  SCHEMA  Documentation/devicetree/bindings/processed-schema.json
  DTC [C] arch/arm64/boot/dts/qcom/sm7325-xiaomi-taoyao.dtb
arch/arm64/boot/dts/qcom/sm7325-xiaomi-taoyao.dtb: /soc@0/display-subsystem@ae00000/dsi@ae94000/panel@0: failed to match any schema with compatible: ['xiaomi,taoyao-panel']
```