### PR TITLE
arm64: dts: qcom: qcm6490-shift-otter: reduce rmtfs_mem from 6MiB to 2.5MiB

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcm6490-shift-otter.dts
+++ b/arch/arm64/boot/dts/qcom/qcm6490-shift-otter.dts
@@ -132,7 +132,7 @@
 
 		rmtfs_mem: rmtfs@f8500000 {
 			compatible = "qcom,rmtfs-mem";
-			reg = <0x0 0xf8500000 0x0 0x600000>;
+			reg = <0x0 0xf8500000 0x0 0x280000>;
 			no-map;
 
 			qcom,client-id = <1>;


### PR DESCRIPTION
The downstream dts still has this at 2.5MiB unlike counterparts such as the Fairphone 5 who set it to 6MiB

https://github.com/SHIFTPHONES/android_kernel_shift_qcm6490/blob/5b43ded8bf11d1d0571ade9979ffee03f9a0b973/arch/arm64/boot/dts/vendor/qcom/yupik.dtsi#L4680