### PR TITLE
arm64: dts: qcom: qcm6490-fairphone-fp5: Use SW_MACHINE_COVER for hall sensor

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcm6490-fairphone-fp5.dts
+++ b/arch/arm64/boot/dts/qcom/qcm6490-fairphone-fp5.dts
@@ -100,7 +100,7 @@
 			label = "Hall Effect Sensor";
 			gpios = <&tlmm 155 GPIO_ACTIVE_LOW>;
 			linux,input-type = <EV_SW>;
-			linux,code = <SW_LID>;
+			linux,code = <SW_MACHINE_COVER>;
 			linux,can-disable;
 			wakeup-source;
 		};


### PR DESCRIPTION
Change the hall effect sensor input code from SW_LID to SW_MACHINE_COVER. SW_MACHINE_COVER is more appropriate for detecting the phone's flip cover state, as SW_LID is typically used for laptop lid switches that trigger suspend behavior.

@z3ntu @lweiss-fairphone I ran into some issues with GNOME Shell/Mutter recognizing the device in a "lid closed" state, introducing some unexpected behavior. I am not 100% certain this is an appropriate change - looking for feedback. What is this sensor actually used for?