### PR TITLE
ASoC: codecs: awinic: fix inverted PCM Playback Volume controls

### DIFF
--- a/sound/soc/codecs/aw88081.c
+++ b/sound/soc/codecs/aw88081.c
@@ -966,8 +966,13 @@ static int aw88081_volume_get(struct snd_kcontrol *kcontrol,
 	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
 	struct aw88081 *aw88081 = snd_soc_component_get_drvdata(codec);
 	struct aw_volume_desc *vol_desc = &aw88081->aw_pa->volume_desc;
+	struct soc_mixer_control *mc =
+		(struct soc_mixer_control *)kcontrol->private_value;
 
 	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+
+	if (mc->invert)
+		ucontrol->value.integer.value[0] = mc->max - ucontrol->value.integer.value[0];
 
 	return 0;
 }
@@ -986,6 +991,9 @@ static int aw88081_volume_set(struct snd_kcontrol *kcontrol,
 
 	if (value < mc->min || value > mc->max)
 		return -EINVAL;
+
+	if (mc->invert)
+		value = mc->max - value;
 
 	aw88083_i2c_wen(aw88081, true);
 
@@ -1034,7 +1042,7 @@ static int aw88081_set_fade_step(struct snd_kcontrol *kcontrol,
 
 static const struct snd_kcontrol_new aw88081_controls[] = {
 	SOC_SINGLE_EXT("PCM Playback Volume", AW88081_SYSCTRL2_REG,
-		0, AW88081_MUTE_VOL, 0, aw88081_volume_get,
+		0, AW88081_MUTE_VOL, 1, aw88081_volume_get,
 		aw88081_volume_set),
 	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88081_MUTE_VOL, 0,
 		aw88081_get_fade_step, aw88081_set_fade_step),

--- a/sound/soc/codecs/aw88166.c
+++ b/sound/soc/codecs/aw88166.c
@@ -1437,8 +1437,13 @@ static int aw88166_volume_get(struct snd_kcontrol *kcontrol,
 	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
 	struct aw88166 *aw88166 = snd_soc_component_get_drvdata(codec);
 	struct aw_volume_desc *vol_desc = &aw88166->aw_pa->volume_desc;
+	struct soc_mixer_control *mc =
+		(struct soc_mixer_control *)kcontrol->private_value;
 
 	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+
+	if (mc->invert)
+		ucontrol->value.integer.value[0] = mc->max - ucontrol->value.integer.value[0];
 
 	return 0;
 }
@@ -1456,6 +1461,9 @@ static int aw88166_volume_set(struct snd_kcontrol *kcontrol,
 	value = ucontrol->value.integer.value[0];
 	if (value < mc->min || value > mc->max)
 		return -EINVAL;
+
+	if (mc->invert)
+		value = mc->max - value;
 
 	if (vol_desc->ctl_volume != value) {
 		vol_desc->ctl_volume = value;
@@ -1615,7 +1623,7 @@ static int aw88166_request_firmware_file(struct aw88166 *aw88166)
 
 static const struct snd_kcontrol_new aw88166_controls[] = {
 	SOC_SINGLE_EXT("PCM Playback Volume", AW88166_SYSCTRL2_REG,
-		6, AW88166_MUTE_VOL, 0, aw88166_volume_get,
+		6, AW88166_MUTE_VOL, 1, aw88166_volume_get,
 		aw88166_volume_set),
 	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88166_MUTE_VOL, 0,
 		aw88166_get_fade_step, aw88166_set_fade_step),

--- a/sound/soc/codecs/aw88261.c
+++ b/sound/soc/codecs/aw88261.c
@@ -894,8 +894,13 @@ static int aw88261_volume_get(struct snd_kcontrol *kcontrol,
 	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
 	struct aw88261 *aw88261 = snd_soc_component_get_drvdata(codec);
 	struct aw_volume_desc *vol_desc = &aw88261->aw_pa->volume_desc;
+	struct soc_mixer_control *mc =
+		(struct soc_mixer_control *)kcontrol->private_value;
 
 	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+
+	if (mc->invert)
+		ucontrol->value.integer.value[0] = mc->max - ucontrol->value.integer.value[0];
 
 	return 0;
 }
@@ -914,6 +919,9 @@ static int aw88261_volume_set(struct snd_kcontrol *kcontrol,
 
 	if (value < mc->min || value > mc->max)
 		return -EINVAL;
+
+	if (mc->invert)
+		value = mc->max - value;
 
 	if (vol_desc->ctl_volume != value) {
 		vol_desc->ctl_volume = value;
@@ -959,7 +967,7 @@ static int aw88261_set_fade_step(struct snd_kcontrol *kcontrol,
 
 static const struct snd_kcontrol_new aw88261_controls[] = {
 	SOC_SINGLE_EXT("PCM Playback Volume", AW88261_SYSCTRL2_REG,
-		6, AW88261_MUTE_VOL, 0, aw88261_volume_get,
+		6, AW88261_MUTE_VOL, 1, aw88261_volume_get,
 		aw88261_volume_set),
 	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88261_MUTE_VOL, 0,
 		aw88261_get_fade_step, aw88261_set_fade_step),

--- a/sound/soc/codecs/aw88395/aw88395.c
+++ b/sound/soc/codecs/aw88395/aw88395.c
@@ -248,8 +248,13 @@ static int aw88395_volume_get(struct snd_kcontrol *kcontrol,
 	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
 	struct aw88395 *aw88395 = snd_soc_component_get_drvdata(codec);
 	struct aw_volume_desc *vol_desc = &aw88395->aw_pa->volume_desc;
+	struct soc_mixer_control *mc =
+		(struct soc_mixer_control *)kcontrol->private_value;
 
 	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+
+	if (mc->invert)
+		ucontrol->value.integer.value[0] = mc->max - ucontrol->value.integer.value[0];
 
 	return 0;
 }
@@ -267,6 +272,9 @@ static int aw88395_volume_set(struct snd_kcontrol *kcontrol,
 	value = ucontrol->value.integer.value[0];
 	if (value < mc->min || value > mc->max)
 		return -EINVAL;
+
+	if (mc->invert)
+		value = mc->max - value;
 
 	if (vol_desc->ctl_volume != value) {
 		vol_desc->ctl_volume = value;
@@ -346,7 +354,7 @@ static int aw88395_re_set(struct snd_kcontrol *kcontrol,
 
 static const struct snd_kcontrol_new aw88395_controls[] = {
 	SOC_SINGLE_EXT("PCM Playback Volume", AW88395_SYSCTRL2_REG,
-		6, AW88395_MUTE_VOL, 0, aw88395_volume_get,
+		6, AW88395_MUTE_VOL, 1, aw88395_volume_get,
 		aw88395_volume_set),
 	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88395_MUTE_VOL, 0,
 		aw88395_get_fade_step, aw88395_set_fade_step),

--- a/sound/soc/codecs/aw88399.c
+++ b/sound/soc/codecs/aw88399.c
@@ -1726,8 +1726,13 @@ static int aw88399_volume_get(struct snd_kcontrol *kcontrol,
 	struct snd_soc_component *codec = snd_kcontrol_chip(kcontrol);
 	struct aw88399 *aw88399 = snd_soc_component_get_drvdata(codec);
 	struct aw_volume_desc *vol_desc = &aw88399->aw_pa->volume_desc;
+	struct soc_mixer_control *mc =
+		(struct soc_mixer_control *)kcontrol->private_value;
 
 	ucontrol->value.integer.value[0] = vol_desc->ctl_volume;
+
+	if (mc->invert)
+		ucontrol->value.integer.value[0] = mc->max - ucontrol->value.integer.value[0];
 
 	return 0;
 }
@@ -1745,6 +1750,9 @@ static int aw88399_volume_set(struct snd_kcontrol *kcontrol,
 	value = ucontrol->value.integer.value[0];
 	if (value < mc->min || value > mc->max)
 		return -EINVAL;
+
+	if (mc->invert)
+		value = mc->max - value;
 
 	if (vol_desc->ctl_volume != value) {
 		vol_desc->ctl_volume = value;
@@ -1951,7 +1959,7 @@ static int aw88399_request_firmware_file(struct aw88399 *aw88399)
 
 static const struct snd_kcontrol_new aw88399_controls[] = {
 	SOC_SINGLE_EXT("PCM Playback Volume", AW88399_SYSCTRL2_REG,
-		6, AW88399_MUTE_VOL, 0, aw88399_volume_get,
+		6, AW88399_MUTE_VOL, 1, aw88399_volume_get,
 		aw88399_volume_set),
 	SOC_SINGLE_EXT("Fade Step", 0, 0, AW88399_MUTE_VOL, 0,
 		aw88399_get_fade_step, aw88399_set_fade_step),


### PR DESCRIPTION
All awinic aw88xxx drivers expose their volume control as raw hardware attenuation, where 0 means full volume and MUTE_VOL means silent. This is the opposite of the ALSA convention where higher values mean louder.

Invert the value at the userspace boundary in the volume_get/volume_set handlers so that ALSA applications and UCM configs see the expected behavior (0 = silent, MUTE_VOL = loudest). The internal ctl_volume representation remains as attenuation so the fade in/out logic is unchanged.

Affects: aw88081, aw88166, aw88261, aw88395, aw88399.

Assisted-By: Claude Opus 4.6