### PR TITLE
Fixups for the Radxa Dragon Q6A

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcs6490-radxa-dragon-q6a.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-radxa-dragon-q6a.dts
@@ -569,11 +569,6 @@
 	status = "okay";
 };
 
-/* It takes a long time in ufshcd_init_crypto when enabled */
-&ice {
-	status = "disabled";
-};
-
 &lpass_audiocc {
 	compatible = "qcom,qcm6490-lpassaudiocc";
 	/delete-property/ power-domains;
@@ -1083,7 +1078,6 @@
 	/* Gear-4 Rate-B is unstable due to board */
 	/* and UFS module design limitations */
 	limit-gear-rate = "rate-a";
-	/delete-property/ qcom,ice;
 
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/qcs6490-radxa-dragon-q6a.dts
+++ b/arch/arm64/boot/dts/qcom/qcs6490-radxa-dragon-q6a.dts
@@ -513,6 +513,9 @@
 			   <GCC_MSS_Q6SS_BOOT_CLK_SRC>,
 			   <GCC_MSS_Q6_MEMNOC_AXI_CLK>,
 			   <GCC_MSS_SNOC_AXI_CLK>,
+			   <GCC_QSPI_CNOC_PERIPH_AHB_CLK>,
+			   <GCC_QSPI_CORE_CLK>,
+			   <GCC_QSPI_CORE_CLK_SRC>,
 			   <GCC_SEC_CTRL_CLK_SRC>,
 			   <GCC_WPSS_AHB_BDG_MST_CLK>,
 			   <GCC_WPSS_AHB_CLK>,
@@ -745,28 +748,6 @@
 	status = "okay";
 };
 
-&qspi {
-	/* It's not possible to use QSPI with iommu */
-	/* due to an error in qcom_smmu_write_s2cr */
-	/delete-property/ iommus;
-
-	pinctrl-0 = <&qspi_clk>, <&qspi_cs0>, <&qspi_data0>,
-				<&qspi_data1>, <&qspi_data23>;
-	pinctrl-1 = <&qspi_sleep>;
-	pinctrl-names = "default", "sleep";
-
-	status = "okay";
-
-	spi_flash: flash@0 {
-		compatible = "winbond,w25q256", "jedec,spi-nor";
-		reg = <0>;
-
-		spi-max-frequency = <104000000>;
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-	};
-};
-
 &qupv3_id_0 {
 	firmware-name = "qcom/qcm6490/qupv3fw.elf";
 	status = "okay";
@@ -906,6 +887,10 @@
 };
 
 &tlmm {
+	/*
+	 * 12-17: reserved for QSPI flash
+	 */
+	gpio-reserved-ranges = <12 6>;
 	gpio-line-names =
 		/* GPIO_0 ~ GPIO_3 */
 		"PIN_13", "PIN_15", "", "",
@@ -1022,12 +1007,6 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
-	};
-
-	qspi_sleep: qspi-sleep-state {
-		pins = "gpio12", "gpio13", "gpio14", "gpio15", "gpio16", "gpio17";
-		function = "gpio";
-		output-disable;
 	};
 
 	sd_cd: sd-cd-state {
@@ -1219,31 +1198,6 @@
 &pcie1_clkreq_n {
 	bias-pull-up;
 	drive-strength = <2>;
-};
-
-&qspi_clk {
-	bias-disable;
-	drive-strength = <16>;
-};
-
-&qspi_cs0 {
-	bias-disable;
-	drive-strength = <8>;
-};
-
-&qspi_data0 {
-	bias-disable;
-	drive-strength = <8>;
-};
-
-&qspi_data1 {
-	bias-disable;
-	drive-strength = <8>;
-};
-
-&qspi_data23 {
-	bias-disable;
-	drive-strength = <8>;
 };
 
 &sdc1_clk {

--- a/drivers/firmware/qcom/qcom_scm.c
+++ b/drivers/firmware/qcom/qcom_scm.c
@@ -2315,6 +2315,7 @@ static const struct of_device_id qcom_scm_qseecom_allowlist[] __maybe_unused = {
 	{ .compatible = "qcom,x1e80100-crd" },
 	{ .compatible = "qcom,x1e80100-qcp" },
 	{ .compatible = "qcom,x1p42100-crd" },
+	{ .compatible = "radxa,dragon-q6a" },
 	{ }
 };
 


### PR DESCRIPTION
The QSEECOM patch allows accessing and setting EFI variables.

The patch to re-enable ICE is a fixup possible thanks to the newer firmware and will hopefully allow for upstreaming the UFS patches, which Radxa said they are planning to do soon.

Feedback from kernel maintainers has shown that the QSPI flash should not be accessible from Linux in their opinion and firmware updates should be done via EFI capsule updates instead. Therefore the other patch makes it managed by the trustzone.