### PR TITLE
arm64: dts: qcom: qcm6490-fairphone-fp5: limit DP link-frequency

### DIFF
--- a/arch/arm64/boot/dts/qcom/qcm6490-fairphone-fp5.dts
+++ b/arch/arm64/boot/dts/qcom/qcm6490-fairphone-fp5.dts
@@ -1071,6 +1071,7 @@
 
 &mdss_dp_out {
 	data-lanes = <0 1>;
+	link-frequencies = /bits/ 64 <2700000000>;
 };
 
 &mdss_dsi {


### PR DESCRIPTION
The DP link training fails if higher than this and it doesn't seem to be able to fallback, pinning it to this rate seems to be safe and fix some more complex docks